### PR TITLE
Bug fix for sorted_search benchmark.

### DIFF
--- a/synthetic/sorted_search/sorted_search.c
+++ b/synthetic/sorted_search/sorted_search.c
@@ -53,17 +53,19 @@ bool linear_search(FLOAT_TYPE data[N], FLOAT_TYPE elem) {
 }
 
 bool binary_search(FLOAT_TYPE data[N], FLOAT_TYPE elem) {
+  // Range under consideration is closed.
+  // i.e. [lo, hi]
   int lo = 0;
-  int hi = N;
-  while(lo != hi) {
+  int hi = N - 1;
+  while(lo <= hi) {
     int mid = (hi+lo) / 2;
     if(data[mid] == elem) {
       return true;
     }
     if(data[mid] > elem) {
-      hi = mid;
+      hi = mid - 1;
     } else {
-      lo = mid;
+      lo = mid + 1;
     }
   }
   return false;


### PR DESCRIPTION
The benchmark would fail to terminate (e.g. if `lo=3`, `hi=4`)
in certain conditions.

It was unclear to me if the range was supposed to be

- Closed [lo,hi]
- Half open [lo, hi)

Part of the code was written as if the range under consideration was
half open but the mid point calculation was written as if the range
was closed.

So I have switched to a closed range and have fixed the assignments
to `mid`.